### PR TITLE
Updated paths. This version uses no `packagePath`.

### DIFF
--- a/dist/hello-world.html
+++ b/dist/hello-world.html
@@ -5,8 +5,7 @@
     <meta charset="UTF-8">
 </head>
 <body>
-        <script src="../node_modules/vss-web-extension-sdk/lib/VSS.SDK.js"></script>
-        <script src="../node_modules/lodash/lodash.js"></script>
+        <script src="../VSS.SDK.js"></script>
         <script type="text/javascript">
             // Initialize the VSS sdk
             VSS.init({
@@ -14,7 +13,7 @@
                 usePlatformStyles: true,
                 moduleLoaderConfig: {
                     paths: {
-                        "dist": "dist"
+                        "lodash": "lodash"
                     }
                 }
             });


### PR DESCRIPTION
This is also completely untested but should get you on the right path.